### PR TITLE
Fix baseurl asset issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.sass-cache/
+_site/

--- a/_config.yml
+++ b/_config.yml
@@ -40,7 +40,7 @@ url: "http://quassy.github.io/"
 # (http://yourusername.github.io/repository-name)
 # and NOT your User repository (http://yourusername.github.io)
 # then add in the baseurl here, like this: "/repository-name"
-baseurl: "/vocalproject.net"
+baseurl: ""
 
 #
 # !! You don't need to change any of the configuration flags below !!


### PR DESCRIPTION
There was a problem where assets were being loaded from `http://vocalproject.net/vocalproject.net/`.

You can see this here:
![before](http://i.imgur.com/P8N2Yzf.png)

After the fix, it looks much better:
![after](http://i.imgur.com/I4d987z.png)

I don't think that I made any breaking changes. 
